### PR TITLE
Change attributes from Literals to List

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+script:
+  - cargo test --verbose
+  - cargo build --verbose 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structype_derive"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["nohupped_arch <nohupped@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/nohupped/structype_derive"
@@ -16,7 +16,8 @@ syn = { version = "1.0.60", features = ["full"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.24"
 serde_json = "1.0.62"
-serde = "1.0.123"
+# serde = {version = "1.0.123", features = ["derive"]}
+serde = {version = "1.0.123"}
 
 [dev-dependencies]
 trybuild = "1.0.41"

--- a/Readme.md
+++ b/Readme.md
@@ -1,48 +1,61 @@
 # Crate structype_derive
 
-This is a derive procedural macro that will let you add custom derive and attributes over structs and enums. This derive will add two impl on the type.print_fields() will print the type field names to the STDOUT, while as_string() returns a json serialized string key-value representation where key is the type's field name and value is the attribute set in `structype_label`. This macro cannot be applied over tuple structs and unit structs.
-This is a derive procedural macro that will let you add custom derive and attributes over structs and enums. This derive will add two impl on the type. `as_string()` returns a json serialized string key-value representation where key is the type's field name and value is the attribute set in the `structype_label`, while`print_fields()` function will print the same to STDOUT. If the `structype_label` is absent, the value will be the same as that of the key. This macro cannot be applied over tuple structs and unit structs, so it will panic if these types are annotated with this derive and won't let you compile.
+This is a derive procedural macro that will let you add custom derive and attributes over structs, enums and unions. This derive will add two impl on the
+type. The `as_string()` method returns a json serialized string representation of the type with any meta information annotated with `structype_meta("key"=val)` attribute while the `print_fields()` method will print the same to STDOUT. This macro will panic at compile time if annotated over tuple and unit structs.
 
 ## Example
 
 ```rust
 use structype_derive::StrucType;
-
 #[derive(StrucType)]
-#[structype_label = "over_ride name"] // This will panic and won't let you compile
-struct MyStruct {
-    #[structype_label = "Overridde name for string"]
-    _my_string: String,
-    #[structype_label = "int_override"]
-    _my_int64: i64,
-    _my_float: f64,
-    _my_nested_struct: MyNestedStruct,
+// #[structype_meta("labelover_ride=name")] This will panic the macro
+struct UserStruct {
+    #[structype_meta(override_name="Primary ID", order="1")]
+    id: i64,
+    #[structype_meta(override_name="name", order="0")]
+    username: String,
+    org: String,
+    details: Details,
 }
 
 #[derive(StrucType)]
-struct MyNestedStruct {
-    _my_nested_struct_string: String,
+struct Details {
+    user_attributes: std::collections::HashMap<String, String>,
 }
 
-fn main() {
-    MyStruct::print_fields();
-    let data = MyStruct::as_string();
+fn print_struct_fields() {
+    UserStruct::print_fields();
+    let data = UserStruct::as_string();
     println!("{}", data);
-    MyNestedStruct::print_fields();
-    let data = MyNestedStruct::as_string();
+    Details::print_fields();
+    let data = Details::as_string();
     println!("{}", data);
 }
 ```
 
+The above will generate and return a json serialized string representation where the key is the struct's field name and the value is a `HashMap<String, String>` of `structype_meta`'s key-val. If the `structype_meta` is absent, the field's associated value would be an empty `{}`.
+
 ## Output
 
-The above snippet will generate and return a json serialized string representation where the key is the struct's field name and the value is the structype_label's value. If the structype_label is absent, the value will be the same as that of the key.
-
 ```json
-{
-    "_my_string": "Overridde name for string",
-    "_my_int64": "int_override",
-    "_my_float": "_my_float",
-    "_my_nested_struct": "_my_nested_struct"
-}
+  [
+      {
+          "id": {
+              "override_name": "Primary ID",
+              "order": "1"
+          }
+      },
+      {
+          "username": {
+              "override_name": "name",
+              "order": "0"
+          }
+      },
+      {
+          "org": {}
+      },
+      {
+          "details": {}
+      }
+  ]
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,31 @@ pub fn structmap(input: TokenStream) -> TokenStream {
                                         }
                                         _ => panic!("Only string value is supported"),
                                     },
+                                    syn::Meta::List(metalist) => {
+                                        let val =metalist.nested
+                                        .into_pairs()
+                                        .map(|pair| pair.into_value())
+                                        .filter_map(|pair| match pair {
+                                            syn::NestedMeta::Meta(meta) => match meta {
+                                                syn::Meta::Path(path) => path.get_ident().cloned(),
+                                                _ => panic!("only path meta supported"),
+                                            },
+                                            //  => panic!("lit not supported"),
+                                            syn::NestedMeta::Lit(lit) => {
+                                                Some(lit)
+                                            }
+                                        })
+                                        .collect::<Vec<_>>();
+                                            // for i in val {
+                                            //     match i {
+                                            //         syn::Lit::Str(_) => {}
+                                            //         _ => panic!("Attributes in string -> value format"),
+                                            //     }
+                                            // }
+                                        }
+                                        
                                     _ => panic!("Path and List is not applicable"),
+                                    // syn::Meta::Path(_) => {}
                                 }
                             }
                         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,63 +1,78 @@
 //! This is a derive procedural macro that will let you add custom derive
-//! and attributes over structs and enums. This derive will add two impl on the
-//! type. `as_string()` returns a json serialized string key-value representation
-//! where key is the type's field name and value is the attribute set in the
-//! `structype_label`, while`print_fields()` function will print the same to STDOUT.
-//! This macro cannot be applied over tuple structs and unit structs, so it will panic if these
-//! types are annotated with this derive and won't let you compile.
+//! and attributes over structs, enums and unions. This derive will add two impl on the
+//! type. The `as_string()` method returns a json serialized string representation of the type
+//! with any meta information annotated with `structype_meta("key"=val)` attribute,
+//! while the `print_fields()` method will print the same to STDOUT.
+//! This macro will panic at compile time if annotated over tuple and unit structs.
 //!
 //! # Example:
 //! ```
 //! use structype_derive::StrucType;
-//!
 //! #[derive(StrucType)]
-//! // #[structype_label = "over_ride name"] // This will panic the macro
-//! struct MyStruct {
-//!     #[structype_label = "Overridde name for string"]
-//!     _my_string: String,
-//!     #[structype_label = "int_override"]
-//!     _my_int64: i64,
-//!     _my_float: f64,
-//!     _my_nested_struct: MyNestedStruct,
+//! // #[structype_meta("labelover_ride=name")] This will panic the macro
+//! struct UserStruct {
+//!     #[structype_meta(override_name="Primary ID", order="1")]
+//!     id: i64,
+//!     #[structype_meta(override_name="name", order="0")]
+//!     username: String,
+//!     org: String,
+//!     details: Details,
 //! }
 //!
 //! #[derive(StrucType)]
-//! struct MyNestedStruct {
-//!     _my_nested_struct_string: String,
+//! struct Details {
+//!     user_attributes: std::collections::HashMap<String, String>,
 //! }
 //!
 //! fn print_struct_fields() {
-//!     MyStruct::print_fields();
-//!     let data = MyStruct::as_string();
+//!     UserStruct::print_fields();
+//!     let data = UserStruct::as_string();
 //!     println!("{}", data);
-//!     MyNestedStruct::print_fields();
-//!     let data = MyNestedStruct::as_string();
+//!     Details::print_fields();
+//!     let data = Details::as_string();
 //!     println!("{}", data);
 //! }
 //! ```
 //! The above will generate and return a json serialized string representation where the key is
-//! the struct's field name and the value is the `structype_label`'s value. If the `structype_label` is
-//! absent, the value will be the same as that of the key.
+//! the struct's field name and the value is a `HashMap<String, String>` of `structype_meta`'s key-val. If the `structype_meta` is
+//! absent, the field's associated value would be an empty `{}`.
 //!
 //! # Output:
 //! ```json
-//! {
-//!	    "_my_string": "Overridde name for string",
-//!	    "_my_int64": "int_override",
-//!	    "_my_float": "_my_float",
-//!	    "_my_nested_struct": "_my_nested_struct"
-//! }
+//!  [
+//!      {
+//!          "id": {
+//!              "override_name": "Primary ID",
+//!              "order": "1"
+//!          }
+//!      },
+//!      {
+//!          "username": {
+//!              "override_name": "name",
+//!              "order": "0"
+//!          }
+//!      },
+//!      {
+//!          "org": {}
+//!      },
+//!      {
+//!          "details": {}
+//!      }
+//!  ]
 //! ```
 
 use proc_macro::{self, TokenStream};
 use quote::quote;
 use std::collections::HashMap;
 use syn::{parse_macro_input, DataEnum, DataUnion, DeriveInput, FieldsNamed};
-
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
+type StrucTypeMap = Vec<TypeMap>;
+
+#[derive(Debug, Clone)]
 struct TypeMap {
-    map: HashMap<String, String>,
+    field_name: String,
+    meta: HashMap<String, String>,
 }
 
 impl Serialize for TypeMap {
@@ -65,15 +80,14 @@ impl Serialize for TypeMap {
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_map(Some(self.map.len()))?;
-        for (k, v) in &self.map {
-            seq.serialize_entry(&k.to_string(), &v)?;
-        }
+        let mut seq = serializer.serialize_map(Some(self.meta.len() + 1))?;
+        seq.serialize_entry(&self.field_name, &self.meta)?;
+
         seq.end()
     }
 }
 
-#[proc_macro_derive(StrucType, attributes(structype_label))]
+#[proc_macro_derive(StrucType, attributes(structype_meta))]
 pub fn structmap(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = parse_macro_input!(input);
     let name = &ast.ident;
@@ -86,124 +100,202 @@ pub fn structmap(input: TokenStream) -> TokenStream {
     }
 
     let description = match &ast.data {
-        syn::Data::Struct(s) => match &s.fields {
-            syn::Fields::Named(FieldsNamed { named, .. }) => {
-                let mut typemap = TypeMap {
-                    map: HashMap::new(),
-                };
-                let iters = named.iter().map(|f| (&f.ident, &f.attrs));
-                for (if_ident, attrs) in iters {
-                    if let Some(ident) = if_ident {
-                        if attrs.len() == 1 {
-                            for attr in attrs.iter() {
-                                let meta = attr.parse_meta().unwrap();
-                                match meta {
-                                    syn::Meta::NameValue(meta_nameval) => match meta_nameval.lit {
-                                        syn::Lit::Str(string_literal) => {
-                                            typemap
-                                                .map
-                                                .insert(ident.to_string(), string_literal.value());
-                                        }
-                                        _ => panic!("Only string value is supported"),
-                                    },
-                                    syn::Meta::List(metalist) => {
-                                        let val =metalist.nested
-                                        .into_pairs()
-                                        .map(|pair| pair.into_value())
-                                        .filter_map(|pair| match pair {
-                                            syn::NestedMeta::Meta(meta) => match meta {
-                                                syn::Meta::Path(path) => path.get_ident().cloned(),
-                                                _ => panic!("only path meta supported"),
-                                            },
-                                            //  => panic!("lit not supported"),
-                                            syn::NestedMeta::Lit(lit) => {
-                                                Some(lit)
+        syn::Data::Struct(s) => {
+            match &s.fields {
+                syn::Fields::Named(FieldsNamed { named, .. }) => {
+                    let mut structype_map: StrucTypeMap = Vec::new();
+                    let iters = named.iter().map(|f| (&f.ident, &f.attrs));
+                    for (if_ident, attrs) in iters {
+                        if let Some(ident) = if_ident {
+                            if attrs.len() > 0 {
+                                let mut record = TypeMap {
+                                    field_name: ident.to_string(),
+                                    meta: HashMap::new(),
+                                };
+                                for attr in attrs.iter() {
+                                    let meta = attr.parse_meta().unwrap();
+                                    match meta {
+                                        syn::Meta::List(metalist) => {
+                                            let pairs = metalist
+                                                .nested
+                                                .into_pairs()
+                                                .map(|pair| pair.into_value());
+                                            for pair in pairs {
+                                                match pair {
+                                                syn::NestedMeta::Meta(meta) => match meta {
+                                                    syn::Meta::Path(_) => {panic!(r#"invalid. Use the format structype_meta(label="foo", ord="10")"#)}
+                                                    syn::Meta::List(_) => {panic!(r#"invalid. Use the format structype_meta(label="foo", ord="10")"#)}
+                                                    syn::Meta::NameValue(meta_nameval) => {
+                                                        let path = meta_nameval.path;
+                                                        match meta_nameval.lit {
+                                                            syn::Lit::Str(str_lit) => {
+
+                                                                record.meta.insert(path.get_ident().unwrap().to_string(), str_lit.value());
+                                                            }
+                                                            _ => {panic!("Only string type is supported now")}
+                                                        }
+                                                    }
+                                                }
+                                                syn::NestedMeta::Lit(_) => {panic!("Lit is not applicable. Annotate as key-value")}
                                             }
-                                        })
-                                        .collect::<Vec<_>>();
-                                            // for i in val {
-                                            //     match i {
-                                            //         syn::Lit::Str(_) => {}
-                                            //         _ => panic!("Attributes in string -> value format"),
-                                            //     }
-                                            // }
+                                            }
+                                            structype_map.push(record.clone());
                                         }
-                                        
-                                    _ => panic!("Path and List is not applicable"),
-                                    // syn::Meta::Path(_) => {}
+
+                                        _ => panic!(
+                                            r#"Not applicable. Present a list of key-value attributes like structype_meta(label="foo", ord="10")"#
+                                        ),
+                                        // syn::Meta::Path(_) => {}
+                                    }
                                 }
+                            } else {
+                                let val = TypeMap {
+                                    field_name: ident.to_string(),
+                                    meta: HashMap::new(),
+                                };
+                                structype_map.push(val);
                             }
-                        } else {
-                            typemap.map.insert(ident.to_string(), ident.to_string());
                         }
                     }
+                    serde_json::to_string(&structype_map).unwrap()
                 }
-                serde_json::to_string(&typemap.map).unwrap()
-            }
-            syn::Fields::Unnamed(_) => panic!("Tuple structs not applicable"),
+                syn::Fields::Unnamed(_) => panic!("Not applicable to Tuple structs"),
 
-            syn::Fields::Unit => panic!("Not applicable to Unit structs"),
-        },
+                syn::Fields::Unit => panic!("Not applicable to Unit structs"),
+            }
+        }
+        // Enums parsing starts here
         syn::Data::Enum(DataEnum { variants, .. }) => {
-            let mut typemap = TypeMap {
-                map: HashMap::new(),
-            };
+            let mut structype_map: StrucTypeMap = Vec::new();
             let iters = variants.iter().map(|f| (&f.ident, &f.attrs));
             for (if_ident, attrs) in iters {
-                if attrs.len() == 1 {
+                if attrs.len() > 0 {
+                    let mut record = TypeMap {
+                        field_name: if_ident.to_string(),
+                        meta: HashMap::new(),
+                    };
                     for attr in attrs.iter() {
                         let meta = attr.parse_meta().unwrap();
                         match meta {
-                            syn::Meta::NameValue(meta_nameval) => match meta_nameval.lit {
-                                syn::Lit::Str(string_literal) => {
-                                    typemap
-                                        .map
-                                        .insert(ast.ident.to_string(), string_literal.value());
+                            syn::Meta::List(metalist) => {
+                                let pairs =
+                                    metalist.nested.into_pairs().map(|pair| pair.into_value());
+                                for pair in pairs {
+                                    match pair {
+                                        syn::NestedMeta::Meta(meta) => match meta {
+                                            syn::Meta::Path(_) => {
+                                                panic!(r#"invalid. Add as key="value#""#)
+                                            }
+                                            syn::Meta::List(_) => {
+                                                panic!(r#"invalid. Add as key="value#""#)
+                                            }
+                                            syn::Meta::NameValue(meta_nameval) => {
+                                                let path = meta_nameval.path;
+                                                match meta_nameval.lit {
+                                                    syn::Lit::Str(str_lit) => {
+                                                        record.meta.insert(
+                                                            path.get_ident().unwrap().to_string(),
+                                                            str_lit.value(),
+                                                        );
+                                                    }
+                                                    _ => {
+                                                        panic!("Only string type is supported now")
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        syn::NestedMeta::Lit(_) => {
+                                            panic!("Lit is not applicable. Annotate as key-value")
+                                        }
+                                    }
                                 }
-                                _ => panic!("Only string value is supported"),
-                            },
-                            _ => panic!("Path and List is not applicable"),
+                                structype_map.push(record.clone());
+                            }
+
+                            _ => panic!(
+                                r#"Not applicable. Present a list of key-value attributes like structype_meta(label="foo", ord="10")"#
+                            ),
+                            // syn::Meta::Path(_) => {}
                         }
                     }
                 } else {
-                    typemap
-                        .map
-                        .insert(if_ident.to_string(), ast.ident.to_string());
+                    let val = TypeMap {
+                        field_name: if_ident.to_string(),
+                        meta: HashMap::new(),
+                    };
+                    structype_map.push(val);
                 }
             }
-            serde_json::to_string(&typemap.map).unwrap()
+            serde_json::to_string(&structype_map).unwrap()
         }
         syn::Data::Union(DataUnion {
             fields: FieldsNamed { named, .. },
             ..
         }) => {
-            let mut typemap = TypeMap {
-                map: HashMap::new(),
-            };
+            let mut structype_map: StrucTypeMap = Vec::new();
             let iters = named.iter().map(|f| (&f.ident, &f.attrs));
             for (if_ident, attrs) in iters {
                 if let Some(ident) = if_ident {
-                    if attrs.len() == 1 {
+                    if attrs.len() > 0 {
+                        let mut record = TypeMap {
+                            field_name: ident.to_string(),
+                            meta: HashMap::new(),
+                        };
                         for attr in attrs.iter() {
                             let meta = attr.parse_meta().unwrap();
                             match meta {
-                                syn::Meta::NameValue(meta_nameval) => match meta_nameval.lit {
-                                    syn::Lit::Str(string_literal) => {
-                                        typemap
-                                            .map
-                                            .insert(ident.to_string(), string_literal.value());
+                                syn::Meta::List(metalist) => {
+                                    let pairs =
+                                        metalist.nested.into_pairs().map(|pair| pair.into_value());
+                                    for pair in pairs {
+                                        match pair {
+                                            syn::NestedMeta::Meta(meta) => match meta {
+                                                syn::Meta::Path(_) => {
+                                                    panic!(r#"invalid. Use the format structype_meta(label="foo", ord="10")"#)
+                                                }
+                                                syn::Meta::List(_) => {
+                                                    panic!(r#"invalid. Use the format structype_meta(label="foo", ord="10")"#)
+                                                }
+                                                syn::Meta::NameValue(meta_nameval) => {
+                                                    let path = meta_nameval.path;
+                                                    match meta_nameval.lit {
+                                                        syn::Lit::Str(str_lit) => {
+                                                            record.meta.insert(
+                                                                path.get_ident()
+                                                                    .unwrap()
+                                                                    .to_string(),
+                                                                str_lit.value(),
+                                                            );
+                                                        }
+                                                        _ => panic!(
+                                                            "Only string type is supported now"
+                                                        ),
+                                                    }
+                                                }
+                                            },
+                                            syn::NestedMeta::Lit(_) => panic!(
+                                                r#"Literal is not applicable. Annotate as key-value like structype_meta(label="foo#", ord="10")"#
+                                            ),
+                                        }
                                     }
-                                    _ => panic!("Only string value is supported"),
-                                },
-                                _ => panic!("Path and List is not applicable"),
+                                    structype_map.push(record.clone());
+                                }
+
+                                _ => panic!(
+                                    r#"Not applicable. Present a list of key-value attributes like structype_meta(label="foo", ord="10")"#
+                                ),
                             }
                         }
                     } else {
-                        typemap.map.insert(ident.to_string(), ident.to_string());
+                        let val = TypeMap {
+                            field_name: ident.to_string(),
+                            meta: HashMap::new(),
+                        };
+                        structype_map.push(val);
                     }
                 }
             }
-            serde_json::to_string(&typemap.map).unwrap()
+            serde_json::to_string(&structype_map).unwrap()
         }
     };
 

--- a/tests/parse_pass.rs
+++ b/tests/parse_pass.rs
@@ -1,42 +1,41 @@
+use std::collections::HashMap;
 use structype_derive::StrucType;
-
 #[derive(StrucType)]
-struct MyStruct {
-    #[structype_label("Overridde name for string", something="another")]
-    _my_string: String,
-    #[structype_label = "int_override"]
-    _my_int64: i64,
-    _my_float: f64,
-    _my_enum: MyEnum,
-    _my_number: f64,
-    _my_nested_struct: MyAnotherStruct,
+// #[structype_meta("labelover_ride=name")] // This will panic the macro
+struct UserStruct {
+    #[structype_meta(override_name = "Primary ID", order = "1")]
+    _id: i64,
+    #[structype_meta(override_name = "name", order = "0")]
+    _username: String,
+    _org: String,
+    _details: Details,
 }
 
 #[derive(StrucType)]
-struct MyAnotherStruct {
-    _my_another_string: String,
+struct Details {
+    _user_attributes: HashMap<String, String>,
 }
 
 #[derive(StrucType)]
 enum MyEnum {
-    #[structype_label = "my_over-ridden-enum"]
+    // #[structype_label = "my_over-ridden-enum"]
     _VariantA,
     _VariantB,
 }
 
 #[derive(StrucType)]
 union MyUnion {
-    #[structype_label = "my_over-ridden-union"]
+    // #[structype_label = "my_over-ridden-union"]
     _unsigned: u32,
     _signed: i32,
 }
 
 fn main() {
-    MyStruct::print_fields();
-    let data = MyStruct::as_string();
+    UserStruct::print_fields();
+    let data = UserStruct::as_string();
     println!("{}", data);
-    MyAnotherStruct::print_fields();
-    let data = MyAnotherStruct::as_string();
+    Details::print_fields();
+    let data = Details::as_string();
     println!("{}", data);
 
     MyEnum::print_fields();

--- a/tests/parse_pass.rs
+++ b/tests/parse_pass.rs
@@ -2,7 +2,7 @@ use structype_derive::StrucType;
 
 #[derive(StrucType)]
 struct MyStruct {
-    #[structype_label = "Overridde name for string"]
+    #[structype_label("Overridde name for string", something="another")]
     _my_string: String,
     #[structype_label = "int_override"]
     _my_int64: i64,


### PR DESCRIPTION
Having only literals doesn't allow keeping multiple attributes, so changing the Literals to List type. 
* The format changes from `#[structype_label = "Overridde name for string"]` to something like `#[structype_meta(override_name="Primary ID", order="1")]`
* The output format changes from a `HashMap<String, String>` to a `vector` of `TypeMap` that holds a `field_name` and a meta field holding `HashMap<String, String>`
* A `Serializer` implementation for `TypeMap` (just to avoid pulling in extra derives other than `Clone` and `Debug`)
* Travis CI